### PR TITLE
Fix nonce issues

### DIFF
--- a/cexapi.class.php
+++ b/cexapi.class.php
@@ -47,7 +47,7 @@ class cexapi {
 	 * Set nonce as timestamp
 	 */
 	private function nonce() {
-		$this->nonce_v = time();
+		$this->nonce_v = round(microtime(true)*100);
 	}
 	 
 	/**


### PR DESCRIPTION
Nonce issues came up when requests were made in the same second. Nonce generation was changed to be based on microseconds.
